### PR TITLE
converting rst to md cross-reference

### DIFF
--- a/docs/src/Appendices/appendix.md
+++ b/docs/src/Appendices/appendix.md
@@ -41,7 +41,7 @@ If *s* and *t* are both Real numbers, they're treated as seconds measured relati
 
 ## Data Requests Syntax
 
-### Channel ID Syntax
+### [Channel ID Syntax](@id channel_id)
 `NN.SSSSS.LL.CC` (net.sta.loc.cha, separated by periods) is the expected syntax for all web functions. The maximum field width in characters corresponds to the length of each field (e.g. 2 for network). Fields can't contain whitespace.
 
 `NN.SSSSS.LL.CC.T` (net.sta.loc.cha.tflag) is allowed in SeedLink. `T` is a single-character data type flag and must be one of `DECOTL`: Data, Event, Calibration, blOckette, Timing, or Logs. Calibration, timing, and logs are not in the scope of SeisBase and may crash SeedLink sessions.
@@ -75,7 +75,7 @@ Allowed wildcards are client-specific.
 * Partial specifiers are OK, but a network and station are always required: `"UW.EL?"` is OK, `".ELK.."` fails.
 
 
-### Channel Configuration Files
+### [Channel Configuration Files](@id channel_config)
 One entry per line, ASCII text, format NN.SSSSS.LL.CCC.D. Due to client-specific wildcard rules, the most versatile configuration files are those that specify each channel most completely:
 
 ```
@@ -111,7 +111,7 @@ CC.VALT..BHN
 CC.VALT..BHE
 ```
 
-### Server List
+### [Server List](@id server)
 
 | String | Source                                |
 | :----- | :---------   |
@@ -138,7 +138,7 @@ CC.VALT..BHE
 | USP    | http://sismo.iag.usp.br               |
 
 
-## SeisBase Standard Keywords
+## [SeisBase Standard Keywords](@id seisbase_std_keyword)
 
 SeisBase.KW is a memory-resident structure of default values for common keywords
 used by package functions. KW has one substructure, SL, with keywords specific
@@ -178,7 +178,7 @@ default for nev to 2.
 .. [`8`] If **w=true**, a file name is automatically generated from the request parameters, in addition to parsing data to a SeisData structure. Files are created from the raw download even if data processing fails, in contrast to get_data(... wsac=true).
 .. _function_list:
 
-## Utility Functions
+## [Utility Functions](@id utility_func)
 This appendix covers utility functions that belong in no other category.
 
 ```@docs
@@ -239,7 +239,7 @@ strings that contain the null character (0x00 or ``'\x0'``).
 |  | "SeisBase" | UInt8 | 6 |
 | `V` | SeisBase file format version | Float32 | 1 |
 | `J` | \# of SeisBase objects in file | UInt32 | 1 |
-| `C` | :ref:`SeisBase object codes<object_codes>` for each object | UInt32 | J |
+| `C` | [SeisBase object codes](@ref seisbase_object_code) for each object | UInt32 | J |
 | `B` | Byte indices for each object | UInt64 | J |
 | {  |   |   |  for i = 1:J |
 |  | (Objects) | variable | J |
@@ -433,7 +433,7 @@ how this field is written to disk.
 | N |  Int64 |  1 |  number of items in dictionary [`1`] |
 | K |  (StringVec) |  1 |  dictionary keys |
 | {  |   |   |  for i = 1:N |
-| c  |  UInt8 |  1 |  :ref:`Type code <type_codes>` of object i |
+| c  |  UInt8 |  1 |  [Type code](@ref other_type_code) of object i |
 | o |  variable |  1 |  object i |
 | }  |   |   |  |
 
@@ -464,7 +464,7 @@ These subtables describe how to read the possible data types in a Misc dictionar
 | str |  UInt8 |  1 |  string |
 
 #### Bits Type (c == 0x00 or 0x01 < c < 0x7f)
-Read a single value whose Type corresponds to the UInt8 :ref:`Type code <type_codes>`.
+Read a single value whose Type corresponds to the UInt8 [Type code](@ref other_type_code).
 
 ### Compound Object Types
 Each of these objects contains at least one of the above simple object types.
@@ -488,11 +488,11 @@ A single channel of data related to a seismic event
 | id |  UInt8 |  Ni |  id string | 
 | Nn |  Int64 |  1 |  size of name string in bytes | 
 | name |  UInt8 |  Nn |  name string | 
-| Lt |  UInt8 |  1 |  :ref:`location Type code<loc_codes>` | 
+| Lt |  UInt8 |  1 |  [location Type codes](@ref loc_type_code) | 
 | loc |  (Loc Type) |  1 |  instrument position | 
 | fs |  Float64 |  1 |  sampling frequency in Hz | 
 | gain |  Float64 |  1 |  scalar gain | 
-| Rt |  UInt8 |  1 |  :ref:`response Type code<resp_codes>` | 
+| Rt |  UInt8 |  1 |  [response Type codes](@ref resp_type_code) | 
 | resp |  (Resp Type) |  1 |  instrument response | 
 | Nu |  Int64 |  1 |  size of units string in bytes | 
 | units |  UInt8 |  Nu |  units string | 
@@ -506,7 +506,7 @@ A single channel of data related to a seismic event
 | notes |  (StringVec) |  1 |  notes and automated logging | 
 | Nt |  Int64 |  1 |  length of time gaps matrix | 
 | T |  Int64 |  2Nt |  time gaps matrix | 
-| Xc |  UInt8 |  1 |  :ref:`Type code <type_codes>` of data vector | 
+| Xc |  UInt8 |  1 |  [Type code](@ref other_type_code) of data vector | 
 | Nx |  Int64 |  1 |  number of samples in data vector | 
 | X |  variable |  NX |  data vector | 
 
@@ -520,11 +520,11 @@ A single channel of univariate geophysical data
 | id | UInt8 | Ni | id string |    
 | Nn | Int64 | 1 | size of name string in bytes |  
 | name | UInt8 | Nn | name string |    
-| Lt | UInt8 | 1 | :ref:`location Type code<loc_codes>` |  
+| Lt | UInt8 | 1 | [location Type codes](@ref loc_type_code) |  
 | loc | (Loc Type) | 1 | instrument position | 
 | fs | Float64 | 1 | sampling frequency in Hz |    
 | gain | Float64 | 1 | scalar gain |   
-| Rt | UInt8 | 1 | :ref:`response Type code<resp_codes>` | 
+| Rt | UInt8 | 1 | [response Type codes](@ref resp_type_code) | 
 | resp | (Resp Type) | 1 | instrument response |   
 | Nu | Int64 | 1 | size of units string in bytes | 
 | units | UInt8 | Nu | units string |  
@@ -534,7 +534,7 @@ A single channel of univariate geophysical data
 | notes | (StringVec) | 1 | notes and automated logging |  
 | Nt | Int64 | 1 | length of time gaps matrix |    
 | T | Int64 | 2Nt | time gaps matrix | 
-| Xc | UInt8 | 1 | :ref:`Type code <type_codes>` of data vector |  
+| Xc | UInt8 | 1 | [Type code](@ref other_type_code) of data vector |  
 | Nx | Int64 | 1 | number of samples in data vector |  
 | X | variable | NX | data vector |    
 
@@ -544,9 +544,9 @@ A multichannel record of time-series data related to a seismic event.
 | Var |  Type |  N |  Meaning |
 | :---- | :---- | :---- | :----
 | N | Int64 | 1 | number of data channels |
-| Lc | UInt8 | N | :ref:`location Type codes<loc_codes>` for each data channel |
-| Rc | UInt8 | N | :ref:`response Type codes<resp_codes>` for each data channel |
-| Xc | UInt8 | N | data :ref:`Type codes <type_codes>` for each data channel |
+| Lc | UInt8 | N | [location Type codes](@ref loc_type_code) for each data channel |
+| Rc | UInt8 | N | [response Type codes](@ref resp_type_code) for each data channel |
+| Xc | UInt8 | N | data [Type code](@ref other_type_code) for each data channel |
 | cmp | UInt8 | 1 | are data compressed? (0x01 = yes) |
 | Nt | Int64 | N | number of rows in time gaps matrix for each channel |
 | Nx | Int64 | N | length of data vector for each channel [`1`] |
@@ -580,9 +580,9 @@ A record containing multiple channels of univariate geophysical data.
 | Var |  Type |  N |  Meaning |
 | :---- | :---- | :---- | :----
 | N | Int64 | 1 | number of data channels |
-| Lc | UInt8 | N | :ref:`location Type codes<loc_codes>` for each data channel |
-| Rc | UInt8 | N | :ref:`response Type codes<resp_codes>` for each data channel |
-| Xc | UInt8 | N | data :ref:`Type codes <type_codes>` for each data channel |
+| Lc | UInt8 | N | [location Type codes](@ref loc_type_code) for each data channel |
+| Rc | UInt8 | N | [response Type codes](@ref resp_type_code) for each data channel |
+| Xc | UInt8 | N | data [Type code](@ref other_type_code) for each data channel |
 | cmp | UInt8 | 1 | are data compressed? (0x01 = yes) |
 | Nt | Int64 | N | number of rows in time gaps matrix for each channel |
 | Nx | Int64 | N | length of data vector for each channel [`1`] |
@@ -665,7 +665,7 @@ A record containing multiple channels of univariate geophysical data.
 Each Type code is written to disk as a UInt8, with the important exception of
 SeisBase custom object Type codes (which use UInt32).
 
-#### Loc Type Codes
+#### [Loc Type Codes](@id loc_type_code)
 
 | UInt8 | Type |
 | :---- | :---- |
@@ -675,7 +675,7 @@ SeisBase custom object Type codes (which use UInt32).
 | 0x03 | XYLoc |
 
 
-#### Resp Type Codes
+#### [Resp Type Codes](@id resp_type_code)
 
 | UInt8 | Type |
 | :---- | :---- |
@@ -684,7 +684,7 @@ SeisBase custom object Type codes (which use UInt32).
 | 0x02 | PZResp64 |
 
 
-#### Other Type Codes
+#### [Other Type Codes](@id other_type_code)
 Only the Types below are faithfully preserved in write/read of a :misc field
 dictionary; other Types are not written to file and can cause ``wseis`` to
 throw errors.
@@ -720,7 +720,7 @@ throw errors.
 |Complex{Float32} | 0x71 | Array{Complex{Float32},N} | 0xf1 |
 |Complex{Float64} | 0x72 | Array{Complex{Float64},N} | 0xf2 |
 
-#### SeisBase Object Type codes
+#### [SeisBase Object Type codes](@id seisbase_object_code)
 
 | UInt32 Code | Object Type |
 | :-------- | :------------ |

--- a/docs/src/Downloading/seedlink.md
+++ b/docs/src/Downloading/seedlink.md
@@ -1,6 +1,6 @@
-# SeedLink
+# [SeedLink](@id seedlink)
 
-[SeedLink](https://www.seiscomp3.org/wiki/doc/applications/seedlink) is a TCP/IP-based data transmission protocol that allows near-real-time access to data from thousands of geophysical monitoring instruments. See :ref:`data keywords list <dkw>` and :ref:`channel id syntax <cid>` for options.
+[SeedLink](https://www.seiscomp3.org/wiki/doc/applications/seedlink) is a TCP/IP-based data transmission protocol that allows near-real-time access to data from thousands of geophysical monitoring instruments. See [data keywords list](@ref seisbase_std_keyword) and [channel id syntax](@ref channel_id) for options.
 
 ```@docs
 seedlink
@@ -17,13 +17,13 @@ Channel specification can use any of the following options:
 
 1. A comma-separated String where each pattern follows the syntax NET.STA.LOC.CHA.DFLAG, e.g. UW.TDH..EHZ.D. Use "?" to match any single character.
 2. An Array{String,1} with one pattern per entry, following the above syntax.
-3. The name of a configuration text file, with one channel pattern per line; see :ref:`Channel Configuration File syntax<ccfg>`.
+3. The name of a configuration text file, with one channel pattern per line; see [Channel Configuration File syntax](@ref channel_config).
 
 **patts**
 Data selection patterns. See official SeedLink documentation; syntax is identical.
 
 ## Keywords
-:ref:`Shared Keywords<dkw>`
+[Shared Keywords](@ref seisbase_std_keyword)
 
 * v, w
 

--- a/docs/src/Downloading/web_services.md
+++ b/docs/src/Downloading/web_services.md
@@ -1,7 +1,7 @@
 # Web Services
 
 Data requests use `get_data!` for FDSN, IRISWS, and IRIS PH5WS data services; for (near)
-real-time streaming, see :ref:`SeedLink<seedlink-section>`.
+real-time streaming, see [SeedLink](@ref seedlink).
 
 ## Time-Series Data
 
@@ -13,17 +13,17 @@ get_data
 Retrieve time-series data from a web archive to SeisData structure **S**.
 
 **method**
-**"FDSN"**: :FDSNWS dataselect. Change FDSN servers with keyword `src` using the :ref:`server list<servers>` (see `?seis_www`).
+**"FDSN"**: :FDSNWS dataselect. Change FDSN servers with keyword `src` using the [server list](@ref server) (see `?seis_www`).
 **"IRIS"**: IRISWS timeseries.
 **"PH5"**: PH5WS timeseries.
 
 **channels**
-:ref:`Channels to retrieve<cid>` -- string, string array, or parameter file.
+[Channels to retrieve](@ref channel_id) -- string, string array, or parameter file.
 Type `?chanspec` at the Julia prompt for more info.
 
 
 ### Keywords
-:ref:`Shared Keywords<dkw>`
+[Shared Keywords](@ref seisbase_std_keyword)
 
 fmt, nd, opts, rad, reg, si, to, v, w, y
 
@@ -66,7 +66,7 @@ FDSNsta
 
 Fill channels `chans` of SeisData structure `S` with information retrieved from remote station XML files by web query.
 
-:ref:`Shared Keywords<dkw>`
+[Shared Keywords](@ref seisbase_std_keyword)
 
 * src, to, v
 

--- a/docs/src/Intro/first_steps.md
+++ b/docs/src/Intro/first_steps.md
@@ -12,7 +12,7 @@ Create a new, empty **SeisChannel** object with
 Ch = SeisChannel()
 ```
 
-The meanings of the field names are explained :ref:`here<dkw>`; you can also type
+The meanings of the field names are explained [here](@ref seisbase_std_keyword); you can also type
 ``?SeisChannel`` at the Julia prompt. You can edit field values manually, e.g.,
 returning to the code block above,
 
@@ -140,5 +140,5 @@ beware of accidental over-matching.
 ## Next Steps
 Because tracking arbitrary operations can be difficult, several functions have
 been written to keep track of data and operations in a semi-automated way. See
-the next section, :ref:`working with data<wwd>`, for detailed discussion of
+the next section, [working with data](@ref working_with_data), for detailed discussion of
 managing data from the Julia command prompt.

--- a/docs/src/Intro/getting_help.md
+++ b/docs/src/Intro/getting_help.md
@@ -1,12 +1,12 @@
 # Getting Help
-In addition to the Juypter notebooks and [online tutorial guide](../../../tutorial/),
+In addition to the Juypter notebooks and [online tutorial guide](https://github.com/JuliaSeismo/SeisBase.jl/tree/main/tutorial),
 other sources of help are available:
 
-* [Examples](@ref)
-* [Tests](@ref)
-* [Command-Line Help](@ref)
+* [Examples](@ref gettinghelp_examples)
+* [Tests](@ref gettinghelp_tests)
+* [Command-Line Help](@ref gettinghelp_clhelp)
 
-## Examples
+## [Examples](@id gettinghelp_examples)
 
 Several worked examples exist throughout these documents, in addition to *examples.jl* and the interactive tutorial.
 
@@ -19,7 +19,7 @@ cd(d)
 include("../test/examples.jl")
 ```
 
-## Tests
+## [Tests](@id gettinghelp_tests)
 The commands in *tests/* can be used as templates; to install test data and run all tests, execute these commands:
 
 ```julia
@@ -30,7 +30,7 @@ p = pathof(SeisBase)
 cd(realpath(dirname(p) * "/../test/"))
 ```
 
-## Command-Line Help
+## [Command-Line Help](@id gettinghelp_clhelp)
 A great deal of additional help functions are available at the Julia command prompt. All SeisBase functions and structures have their own docstrings. For example, typing `?SeisData` at the Julia prompt produces the following:
 
 ```@docs
@@ -66,12 +66,12 @@ These functions contain help docstrings but execute nothing. They exist to answe
 web_chanspec
 ```
 
-Answers: how do I specify channels in a web request? Outputs :ref:`channel id syntax <cid>` to stdout.
+Answers: how do I specify channels in a web request? Outputs [channel id syntax](@ref channel_id) to stdout.
 
 ```@docs
 seis_www
 ```
-Answers: which servers are available for FDSN queries? Outputs :ref:`the FDSN server list<servers>` to stdout.
+Answers: which servers are available for FDSN queries? Outputs [the FDSN server list](@ref server) to stdout.
 
 ```@docs
 TimeSpec

--- a/docs/src/Intro/working_with_data.md
+++ b/docs/src/Intro/working_with_data.md
@@ -1,4 +1,4 @@
-# Working with Data
+# [Working with Data](@id working_with_data)
 This section is a tutorial for tracking and managing SeisBase data.
 
 ## Creating Data Containers
@@ -19,10 +19,10 @@ Create a new, empty object using any of the following commands:
 ## Keeping Track
 A number of auxiliary functions exist to keep track of channels:
 
+* [`namestrip`](@ref utility_func)
 ```@docs
 findchan
 findid
-namestrip
 ```
 | Convention | Characters Removed:sup:`¹`                 |
 | ---------- | ------------------------------------------ | 

--- a/docs/src/ReadingFiles/hdf5.md
+++ b/docs/src/ReadingFiles/hdf5.md
@@ -9,9 +9,9 @@ read_hdf5!(S::GphysData, fname::String, s::TimeSpec, t::TimeSpec, [, KWs])
 
 Read data in seismic HDF5 file format from file **fname** into S.
 **KWs**
-Keyword arguments; see also :ref:`SeisBase standard KWs<dkw>` or type `?SeisBase.KW`.
+Keyword arguments; see also [Shared Keywords](@ref seisbase_std_keyword) or type `?SeisBase.KW`.
 
-This has one fundamental design difference from :ref:`read_data<readdata>`:
+This has one fundamental design difference from [read_data](@ref time_series_file):
 HDF5 archives are assumed to be large files with data from multiple channels;
 they are scanned selectively for data of interest to read, rather than read
 into memory in their entirety.
@@ -21,10 +21,10 @@ into memory in their entirety.
 | KW     | Type      | Default    | Meaning                                                   |
 | ------ | --------- | ---------- | --------------------------------------------------------- |
 |  id    | String    | \"*.*..*\" | id pattern, formated nn.sss.ll.ccc                        |
-|        |           |            |  (net.sta.loc.cha); FDSN-style wildcards [^1]             |
+|        |           |            |  (net.sta.loc.cha); FDSN-style wildcards [1]             |
 |  msr   | Bool      | true       | read full (MultiStageResp) instrument resp?               |
 |  v     | Integer   | 0          | verbosity                                                 |
 
-[^1]: A question mark ('?') is a wildcard for a single character (exactly one); an asterisk ('*') is a wildcard for zero or more characters.
+1. A question mark ('?') is a wildcard for a single character (exactly one); an asterisk ('*') is a wildcard for zero or more characters.
 
-Writing to HDF5 volumes is supported through *write_hdf5*, described in :ref:`Writing to File<write>`.
+Writing to HDF5 volumes is supported through *write_hdf5*, described in [Writing to File](@ref write_support).

--- a/docs/src/ReadingFiles/timeseries.md
+++ b/docs/src/ReadingFiles/timeseries.md
@@ -1,4 +1,4 @@
-# Time-Series Files
+# [Time-Series Files](@id time_series_file)
 
 ```@docs
 read_data!
@@ -123,7 +123,7 @@ for a list.
 
 ## Format-Specific Information
 
-### SEG Y
+### [SEG Y](@id segy)
 Only SEG Y rev 0 and [rev 1](https://seg.org/Portals/0/SEG/News%20and%20Resources/Technical%20Standards/seg_y_rev1.pdf) with standard headers are supported. The following are known support limitations:
 
 1. A few SEG Y headers are partially implemented or unused. These will be refined as we obtain more test data with standardized SEG Y headers and known results.

--- a/docs/src/ReadingFiles/xml.md
+++ b/docs/src/ReadingFiles/xml.md
@@ -30,7 +30,7 @@ Almost never. By default, the **:resp** field of each channel contains a
 simple instrument response with poles, zeros, sensitivity (**:a0**), and
 sensitivity frequency (**:f0**). Very few use cases require more detail.
 
-## QuakeML
+## [QuakeML](@id quakeml)
 
 ```@docs
 read_qml

--- a/docs/src/Submodules/quake.md
+++ b/docs/src/Submodules/quake.md
@@ -27,33 +27,33 @@ SeisBase.Quake.get_pha!
 
 ### Web Query Keywords
 
-| KW     | Default        | T [`1`] | Meaning                                 |
+| KW     | Default        | T [1] | Meaning                                   |
 | :----- | :------------- | :----- | :----------------------------------------|
-| evw    | [600.0, 600.0] | A{F,1} | search window in seconds [`2`]           |
+| evw    | [600.0, 600.0] | A{F,1} | search window in seconds [2]             |
 | fmt    | "miniseed"     | S      | request data format                      |
 | len    | 120.0          | I      | desired trace length [s]                 |
 | mag    | [6.0, 9.9]     | A{F,1} | magnitude range for queries              |
 | model  | "iasp91"       | S      | Earth velocity model for phase times     |
 | nd     | 1              | I      | number of days per subrequest            |
-| nev    | 0              | I      | number of events returned per query [`3`] |
-| opts   | ""             | S      | user-specified options [`4`]             |
-| pha    | "P"            | S      | phases to get [`5`]                      |
-| rad    | []             | A{F,1} | radial search region [`6`]               |
-| reg    | []             | A{F,1} | rectangular search region [`7`]          |
+| nev    | 0              | I      | number of events returned per query [3]  |
+| opts   | ""             | S      | user-specified options [4]               |
+| pha    | "P"            | S      | phases to get [5]                        |
+| rad    | []             | A{F,1} | radial search region [6]                 |
+| reg    | []             | A{F,1} | rectangular search region [7]            |
 | src    | "IRIS"         | S      |  data source; type *?seis_www* for list  |
 | to     | 30             | I      | read timeout for web requests [s]        |
 | v      | 0              | I      | verbosity                                |
-| w      | false          | B      | write requests to disk? [`8`]            |
+| w      | false          | B      | write requests to disk? [8]              |
 
 **Table Footnotes**
-* [`1`] Types: A = Array, B = Boolean, C = Char, DT = DateTime, F = Float, I = Integer, S = String, U8 = Unsigned 8-bit integer (UInt8)
-* [`2`] search range is always ``ot-|evw[1]| ≤ t ≤ ot+|evw[2]|``
-* [`3`] nev=0 returns all events in the query
-* [`4`] String is passed as-is, e.g. "szsrecs=true&repo=realtime" for FDSN. String should not begin with an ampersand.
-* [`5`] Comma-separated String, like `"P, pP"`; use `"ttall"` for all phases
-* [`6`] Specify region **[center_lat, center_lon, min_radius, max_radius, dep_min, dep_max]**, with lat, lon, and radius in decimal degrees (°) and depth in km with + = down. Depths are only used for earthquake searches.
-* [`7`] Specify region **[lat_min, lat_max, lon_min, lon_max, dep_min, dep_max]**, with lat, lon in decimal degrees (°) and depth in km with + = down. Depths are only used for earthquake searches.
-* [`8`] If **w=true**, a file name is automatically generated from the request parameters, in addition to parsing data to a SeisData structure. Files are created from the raw download even if data processing fails, in contrast to get_data(... wsac=true).
+1. Types: A = Array, B = Boolean, C = Char, DT = DateTime, F = Float, I = Integer, S = String, U8 = Unsigned 8-bit integer (UInt8)
+2. search range is always ``ot-|evw[1]| ≤ t ≤ ot+|evw[2]|``
+3. nev=0 returns all events in the query
+4. String is passed as-is, e.g. "szsrecs=true&repo=realtime" for FDSN. String should not begin with an ampersand.
+5. Comma-separated String, like `"P, pP"`; use `"ttall"` for all phases
+6. Specify region **[center_lat, center_lon, min_radius, max_radius, dep_min, dep_max]**, with lat, lon, and radius in decimal degrees (°) and depth in km with + = down. Depths are only used for earthquake searches.
+7. Specify region **[lat_min, lat_max, lon_min, lon_max, dep_min, dep_max]**, with lat, lon in decimal degrees (°) and depth in km with + = down. Depths are only used for earthquake searches.
+8. If **w=true**, a file name is automatically generated from the request parameters, in addition to parsing data to a SeisData structure. Files are created from the raw download even if data processing fails, in contrast to get_data(... wsac=true).
 
 ### Example
 Get seismic and strainmeter records for the P-wave of the Tohoku-Oki great earthquake on two borehole stations and write to native SeisData format:
@@ -81,7 +81,5 @@ SeisBase.Quake.read_quake
 
 ### QuakeML
 
-* [`read_qml`](@ref)
-```@docs
-SeisBase.Quake.write_qml
-```
+* [`read_qml`](@ref quakeml)
+* [`write_qml`](@ref write_qml)

--- a/docs/src/Submodules/seishdf.md
+++ b/docs/src/Submodules/seishdf.md
@@ -1,4 +1,4 @@
-# SeisHDF
+# [SeisHDF](@id seishdf)
 This submodule contains dedicated support for seismic subformats of the HDF5 file format.
 
 ## Additional Functions

--- a/docs/src/WritingFiles/writing.md
+++ b/docs/src/WritingFiles/writing.md
@@ -1,4 +1,4 @@
-# Write Suppport
+# [Write Suppport](@id write_support)
 The table below sumamrizes the current write options for SeisBase. Each function is described in detail in this chapter.
 
 | Structure/Description                 | Output Format         | Function      |
@@ -25,7 +25,7 @@ The table below sumamrizes the current write options for SeisBase. Each function
 | any SeisBase structure                | SeisBase file         | wseis         |
 | primitive data type or array          | ASDF AuxiliaryData    | asdf_waux     |
 
-Methods for SeisEvent, SeisHdr, or SeisSrc are part of submodule SeisBase.Quake. *asdf_waux* and *asdf_wqml* are part of :ref:`SeisBase.SeisHDF.<seishdf>`.
+Methods for SeisEvent, SeisHdr, or SeisSrc are part of submodule SeisBase.Quake. *asdf_waux* and *asdf_wqml* are part of [SeisBase.SeisHDF](@ref seishdf).
 
 
 ## Write Functions
@@ -36,10 +36,10 @@ Functions are organized by file format.
 write_hdf5
 ```
 
-## QuakeML
+## [QuakeML](@id write_qml)
 
 ```@docs
-write_qml
+SeisBase.Quake.write_qml
 ```
 
 ## SAC

--- a/src/Processing/Resp/resptofc.jl
+++ b/src/Processing/Resp/resptofc.jl
@@ -9,7 +9,6 @@ oscillators with a single lower corner frequency) at low frequencies.
 
 See also: `fctoresp`, `PZResp`
 """
-
 function resptofc(R::Union{PZResp, PZResp64})
   T = typeof(R.a0)
   P = R.p

--- a/src/Processing/convert_seis.jl
+++ b/src/Processing/convert_seis.jl
@@ -31,7 +31,7 @@ Convert all seismic data channels in `S` to velocity seismograms, differentiatin
     uses an in-place variant of [Kahan-Babuška-Neumaier summation](https://github.com/JuliaMath/KahanSummation.jl)
 
 ### References
-[^1] Neumaier, A. (1974). "Rundungsfehleranalyse einiger Verfahren zur Summation endlicher Summen" [Rounding Error Analysis of Some Methods for Summing Finite Sums]. Zeitschrift für Angewandte Mathematik und Mechanik (in German). 54 (1): 39–51. doi:10.1002/zamm.19740540106.
+1. Neumaier, A. (1974). "Rundungsfehleranalyse einiger Verfahren zur Summation endlicher Summen" [Rounding Error Analysis of Some Methods for Summing Finite Sums]. Zeitschrift für Angewandte Mathematik und Mechanik (in German). 54 (1): 39-51. doi:10.1002/zamm.19740540106.
 
 """
 function convert_seis!(S::GphysData;

--- a/src/Processing/filtfilt.jl
+++ b/src/Processing/filtfilt.jl
@@ -154,20 +154,20 @@ Keywords control filtering behavior; specify as e.g. filtfilt!(S, fl=0.1, np=2, 
 
 | Name  | Default       | Type    | Description                         |
 |:------|:--------------|:--------|:------------------------------------|
-| chans | (all)         | [^1]    | channel numbers to filter           |
-| fl    | 1.0           | Float64 | lower corner frequency [Hz] [^2]    |
-| fh    | 15.0          | Float64 | upper corner frequency [Hz] [^2]    |
+| chans | (all)         | [1]    | channel numbers to filter            |
+| fl    | 1.0           | Float64 | lower corner frequency [Hz] [2]     |
+| fh    | 15.0          | Float64 | upper corner frequency [Hz] [2]     |
 | np    | 4             | Int64   | number of poles                     |
 | rp    | 10            | Int64   | pass-band ripple (dB)               |
 | rs    | 30            | Int64   | stop-band ripple (dB)               |
 | rt    | "Bandpass"    | String  | response type (type of filter)      |
 | dm    | "Butterworth" | String  | design mode (name of filter)        |
 
-[^1]: Allowed types are Integer, UnitRange, and Array{Int64, 1}.
-[^2]: By convention, the lower corner frequency (fl) is used in a Highpass
+1. Allowed types are Integer, UnitRange, and Array{Int64, 1}.
+2. By convention, the lower corner frequency (fl) is used in a Highpass
 filter, and fh is used in a Lowpass filter.
 
-Default filtering KW values can be changed by adjusting the :ref:`shared keywords<dkw>`, 
+Default filtering KW values can be changed by adjusting the [Shared Keywords](@ref seisbase_std_keyword), 
 e.g., `SeisBase.KW.Filt.np = 2` changes the default number of poles to 2.
 
 See also: DSP.jl documentation

--- a/src/Submodules/Nodal/Types/NodalData.jl
+++ b/src/Submodules/Nodal/Types/NodalData.jl
@@ -16,7 +16,7 @@ SeisChannel variant for a channel from a nodal array.
 | :ox    | Origin longitude                                                 |
 | :oy    | Origin latitude                                                  |
 | :oz    | Origin elevation                                                 |
-| :info  | Critical array info, shared by all sensors. [^1]                 |
+| :info  | Critical array info, shared by all sensors. [1]                  |
 | :id    | Channel id. Uses NET.STA.LOC.CHA format when possible            |
 | :name  | Freeform channel name                                            |
 | :loc   | Location (position) vector; only accepts NodalLoc                |
@@ -31,7 +31,7 @@ SeisChannel variant for a channel from a nodal array.
 | :data  | Matrix underlying time-series data                               |
 | :x     | Views into :data corresponding to each channel                   |
 
-[^1] Not present in, or retained by, NodalChannel objects.
+1. Not present in, or retained by, NodalChannel objects.
 
 See also: `SeisData`, `InstrumentPosition`, `InstrumentResponse`
 """

--- a/src/Submodules/Nodal/Wrappers/read_nodal.jl
+++ b/src/Submodules/Nodal/Wrappers/read_nodal.jl
@@ -8,11 +8,11 @@ Read nodal data from file `filestr` into new NodalData object `S`.
 |:---   |:---       |:---       |:---       |:---                             |
 | chans | ChanSpec  | Int64[]   | all       | channel numbers to read in      |
 | nn    | String    | "N0"      | all       | network name in `:id`           |
-| s     | TimeSpec  |           | silixa    | start time [^1]                 |
+| s     | TimeSpec  |           | silixa    | start time [1]                  |
 | t     | TimeSpec  |           | silixa    | end time                        |
 | v     | Integer   | 0         | silixa    | verbosity                       |
 
-[^1] Special behavior: Real values supplied to `s=` and `t=` are treated as seconds *from file begin*; 
+1. Special behavior: Real values supplied to `s=` and `t=` are treated as seconds *from file begin*; 
     most SeisBase functions treat Real as seconds relative to current time.
 
 ## Non-Standard Behavior
@@ -39,7 +39,7 @@ Most SeisBase functions that accept TimeSpec arguments treat Real values as seco
     * frequency response; currently ``:resp`` is an all-pass placeholder
 
 ## Nodal SEG Y Support Status
-See :ref:`SEG Y Support<segy-support>`.
+See [SEG Y Support](@ref segy).
 
 
 See also: `TimeSpec`, `parsetimewin`, `read_data`

--- a/src/Submodules/Quake/Types/EventTraceData.jl
+++ b/src/Submodules/Quake/Types/EventTraceData.jl
@@ -15,7 +15,7 @@ discrete event (earthquake).
 
 | **Field** | **Description**                                               |
 |:-------|:------                                                           |
-| :n     | Number of channels [^1]                                          |
+| :n     | Number of channels [1]                                          |
 | :id    | Channel id. Uses NET.STA.LOC.CHA format when possible            |
 | :name  | Freeform channel name                                            |
 | :loc   | Location (position) vector; any subtype of InstrumentPosition    |
@@ -33,7 +33,7 @@ discrete event (earthquake).
 | :t     | Matrix of time gaps in integer μs, formatted [Sample# Length]    |
 | :x     | Time-series data                                                 |
 
-[^1]: Not present in EventChannel objects.
+1. Not present in EventChannel objects.
 
 See also: `PhaseCat`, `SeisPha`, `SeisData`
 """

--- a/src/Submodules/Quake/Web/FDSN.jl
+++ b/src/Submodules/Quake/Web/FDSN.jl
@@ -8,21 +8,21 @@ Returns an Array{SeisHdr,1} in H with event headers and an Array{SeisSrc,1}
 in R in H with corresponding source process info.
 
 ### Keywords
-| KW       | Default      | T [^1]    | Meaning                        |
+| KW       | Default      | T [1]    | Meaning                         |
 |----------|:-----------  |:----------|:-------------------------------|
-| evw      | [600., 600.] | Float64   | search window in seconds [^2]  |
+| evw      | [600., 600.] | Float64   | search window in seconds [2]   |
 | mag      | [6.0, 9.9]   | Float64   | search magitude range          |
-| nev      | 0            | Integer   | events per query [^3]          |
+| nev      | 0            | Integer   | events per query [3]           |
 | rad      | []           | Float64   | radius search                  |
 | reg      | []           | Float64   | geographic search region       |
-| src [^4] | "IRIS"       | String    | data source; `?seis_www` lists |
+| src [4]  | "IRIS"       | String    | data source; `?seis_www` lists |
 | to       | 30           | Int64     | timeout (s) for web requests   |
 | v        | 0            | Integer   | verbosity                      |
 
-[^1]: `Array{T, 1}` for `evw`, `mag`, `rad`, `reg`; `T` for others
-[^2]: search range is always `ot-|evw[1]| ≤ t ≤ ot+|evw[2]|`
-[^3]: if `nev=0`, all matches are returned.
-[^4]: In an event query, keyword `src` can be a comma-delineated list, like `"IRIS, INGV, NCEDC"`.
+1. `Array{T, 1}` for `evw`, `mag`, `rad`, `reg`; `T` for others
+2. search range is always `ot-|evw[1]| ≤ t ≤ ot+|evw[2]|`
+3. if `nev=0`, all matches are returned.
+4. In an event query, keyword `src` can be a comma-delineated list, like `"IRIS, INGV, NCEDC"`.
 
 ### Notes
 
@@ -133,16 +133,16 @@ Get header and trace data for the event closest to origin time `ot` on channels
 `chans`. Returns a SeisEvent structure.
 
 ### Keywords
-| KW       | Default      | T [^1]    | Meaning                        |
+| KW       | Default      | T [1]    | Meaning                         |
 |----------|:-----------  |:----------|:-------------------------------|
-| evw      | [600., 600.] | Float64   | search window in seconds [^2]  |
+| evw      | [600., 600.] | Float64   | search window in seconds [2]   |
 | fmt      | "miniseed"   | String    | request data format            |
 | len      | 120.0        | Float64   | desired trace length [s]       |
 | mag      | [6.0, 9.9]   | Float64   | search magitude range          |
 | model    | "iasp91"     | String    | velocity model for phases      |
 | nd       | 1            | Real      | number of days per subrequest  |
-| opts     | ""           | String    | user-specified options[^3]     |
-| pha      | "P"          | String    | phases to get  [^4]            |
+| opts     | ""           | String    | user-specified options[3]      |
+| pha      | "P"          | String    | phases to get  [4]             |
 | rad      | []           | Float64   | radius search                  |
 | reg      | []           | Float64   | geographic search region       |
 | src      | "IRIS"       | String    | data source; `?seis_www` lists |
@@ -150,10 +150,10 @@ Get header and trace data for the event closest to origin time `ot` on channels
 | v        | 0            | Integer   | verbosity                      |
 | w        | false        | Bool      | write requests to disk?        |
 
-[^1]: KW is `Array{T, 1}` for `evw`, `mag`, `rad`, `reg`, type `T` for others
-[^2]: Search range is always `ot-|evw[1]| ≤ t ≤ ot+|evw[2]|`
-[^3]: Format like an http request string, e.g. "szsrecs=true&repo=realtime" for FDSN. String shouldn't begin with an ampersand.
-[^4]: Comma-separated String, like `"P, pP"`; use `"ttall"` for all phases
+1. KW is `Array{T, 1}` for `evw`, `mag`, `rad`, `reg`, type `T` for others
+2. Search range is always `ot-|evw[1]| ≤ t ≤ ot+|evw[2]|`
+3. Format like an http request string, e.g. "szsrecs=true&repo=realtime" for FDSN. String shouldn't begin with an ampersand.
+4. Comma-separated String, like `"P, pP"`; use `"ttall"` for all phases
 
 ### Notes
 

--- a/src/Submodules/Quake/Web/IRIS.jl
+++ b/src/Submodules/Quake/Web/IRIS.jl
@@ -12,8 +12,8 @@ Keywords:
 * v: verbosity
 
 ### References
-[1] TauP manual: http://www.seis.sc.edu/downloads/TauP/taup.pdf
-[2] Crotwell, H. P., Owens, T. J., & Ritsema, J. (1999). The TauP Toolkit:
+1. TauP manual: http://www.seis.sc.edu/downloads/TauP/taup.pdf
+2. Crotwell, H. P., Owens, T. J., & Ritsema, J. (1999). The TauP Toolkit:
 Flexible seismic travel-time and ray-path utilities, SRL 70(2), 154-160.
 """
 function get_pha!(Ev::SeisEvent;

--- a/src/Submodules/RandSeis/randSeisChannel.jl
+++ b/src/Submodules/RandSeis/randSeisChannel.jl
@@ -178,12 +178,12 @@ Generate a random channel of geophysical time-series data as a SeisChannel.
 |-------- |:--------|:----------|:-------------------------------         |
 | s       | false   | Bool      | force channel to have seismic data?     |
 | c       | false   | Bool      | force channel to have irregular data?   |
-| nx      | 0       | Int64     | number of samples in channel [^1]       |
+| nx      | 0       | Int64     | number of samples in channel [1]        |
 | fs_min  | 0.0     | Float64   | channels will have fs ≥ fs_min          |
-| fc      | 0.0     | Float64   | rolloff frequency [^2]                  |
+| fc      | 0.0     | Float64   | rolloff frequency [2]                   |
 
-[^1]: if `nx ≤ 0`, the number of samples is determined randomly
-[^2]: specifing `fc` with `c=false` returns a geophone instrument response
+1. if `nx ≤ 0`, the number of samples is determined randomly
+2. specifing `fc` with `c=false` returns a geophone instrument response
 
 See also: `randSeisData`, `fctoresp`
 """

--- a/src/Submodules/SeisHDF/asdf_qml.jl
+++ b/src/Submodules/SeisHDF/asdf_qml.jl
@@ -104,10 +104,10 @@ As above, for the `:hdr` and `:source` fields of `evt`.
 
 |KW     | Type      | Default   | Meaning                                     |
 |:---   |:---       |:---       |:---                                         |
-| ovr   | Bool      | false     | overwrite QML in existing ASDF file? [^1]   |
+| ovr   | Bool      | false     | overwrite QML in existing ASDF file? [1]    |
 | v     | Integer   | 0         | verbosity                                   |
 
-[^1] By default, data are appended to the existing contents of "QuakeML/".
+1. By default, data are appended to the existing contents of "QuakeML/".
 
 !!! warning
 

--- a/src/Submodules/SeisHDF/read_hdf5.jl
+++ b/src/Submodules/SeisHDF/read_hdf5.jl
@@ -10,11 +10,11 @@ type `?TimeSpec` for more information about how these are interpreted.
 |KW     | Type      | Default   | Meaning                                     |
 |:---   |:---       |:---       |:---                                         |
 | id    | String    | "*"       | id pattern, formated nn.sss.ll.ccc          |
-|       |           |           |  (net.sta.loc.cha); FDSN wildcards [^1]     |
+|       |           |           |  (net.sta.loc.cha); FDSN wildcards [1]      |
 | msr   | Bool      | true      | read full (MultiStageResp) instrument resp? |
 | v     | Integer   | 0         | verbosity                                   |
 
-[^1] A question mark ('?') is a wildcard for a single character; an asterisk ('*') is a wildcard for zero or more characters
+1. A question mark ('?') is a wildcard for a single character; an asterisk ('*') is a wildcard for zero or more characters
 
 See also: `TimeSpec`, `parsetimewin`, `read_data`
 """ read_hdf5!

--- a/src/Types/KWDefs.jl
+++ b/src/Types/KWDefs.jl
@@ -69,7 +69,7 @@ keyword isn't specified.
 
 | KW       | Default    | Allowed Data Types | Meaning                        |
 |----------|:-----------|:-------------------|:-------------------------------|
-| comp     | 0x00       | UInt8              | compress data on write?[^1]    |
+| comp     | 0x00       | UInt8              | compress data on write?[1]     |
 | fmt      | "miniseed" | String             | request data format            |
 | full     | false      | Bool               | read full headers?             |
 | n_zip    | 100000     | Int64              | compress if length(x) > n_zip  |
@@ -78,7 +78,7 @@ keyword isn't specified.
 |          |            |                    |  undersized data array         |
 | nx_new   | 8640000    | Int64              | number of samples allocated    |
 |          |            |                    |   for a new data channel       |
-| opts     | ""         | String             | user-specified options[^2]     |
+| opts     | ""         | String             | user-specified options[2]      |
 | prune    | true       | Bool               | call prune! after get_data?    |
 | rad      | []         | Array{Float64,1}   | radius search: `[center_lat,`  |
 |          |            |                    |   `center_lon, r_min, r_max]`  |
@@ -96,15 +96,15 @@ keyword isn't specified.
 | w        | false      | Bool               | write requests to disk?        |
 | y        | false      | Bool               | sync after web requests?       |
 
-[^1]: If `comp == 0x00`, never compress data; if `comp == 0x01`, only compress channel `i` if `length(S.x[i]) > KW.n_zip`; if `comp == 0x02`, always compress data.
-[^2]: Format like an http request string, e.g. "szsrecs=true&repo=realtime" for FDSN. String shouldn't begin with an ampersand.
+1. If `comp == 0x00`, never compress data; if `comp == 0x01`, only compress channel `i` if `length(S.x[i]) > KW.n_zip`; if `comp == 0x02`, always compress data.
+2. Format like an http request string, e.g. "szsrecs=true&repo=realtime" for FDSN. String shouldn't begin with an ampersand.
 
 ### SeisBase.KW.SL
 Seedlink-specific keyword default values. SeedLink also uses some general keywords.
 
 | Name    | Default | Type    | Description                                 |
 |:--------|:--------|:--------|:----------------------------------          |
-| gap     | 3600    | Real    | allowed time since last packet [s] [^1]     |
+| gap     | 3600    | Real    | allowed time since last packet [s] [1]      |
 | kai     | 600     | Real    | keepalive interval [s]                      |
 | port    | 18000   | Int64   | port number                                 |
 | refresh | 20      | Real    | base refresh interval [s]                   |
@@ -112,22 +112,22 @@ Seedlink-specific keyword default values. SeedLink also uses some general keywor
 | u       | (iris)  | String  | Default URL ("rtserve.iris.washington.edu") |
 | xonerr  | true    | Bool    | exit on error?                              |
 
-[^1]: A channel is considered non-transmitting (hence, excluded from the SeedLink session) if the time since last packet exceeds `gap` seconds.
+1. A channel is considered non-transmitting (hence, excluded from the SeedLink session) if the time since last packet exceeds `gap` seconds.
 
 ### SeisBase.KW.Filt
 Default keyword values for time-series filtering.
 
 | Name  | Default       | Type    | Description                         |
 |:------|:--------------|:--------|:------------------------------------|
-| fl    | 1.0           | Float64 | lower corner frequency [Hz] [^1]    |
-| fh    | 15.0          | Float64 | upper corner frequency [Hz] [^1]    |
+| fl    | 1.0           | Float64 | lower corner frequency [Hz] [1]     |
+| fh    | 15.0          | Float64 | upper corner frequency [Hz] [1]     |
 | np    | 4             | Int64   | number of poles                     |
 | rp    | 8             | Int64   | pass-band ripple (dB)               |
 | rs    | 30            | Int64   | stop-band ripple (dB)               |
 | rt    | "Bandpass"    | String  | response type (type of filter)      |
 | dm    | "Butterworth" | String  | design mode (name of filter)        |
 
-[^1]: Remember the (counter-intuitive) convention that the lower corner frequency (fl) is used in a Highpass filter, and fh is used in a Lowpass filter. This convention is preserved in SeisBase.
+1. Remember the (counter-intuitive) convention that the lower corner frequency (fl) is used in a Highpass filter, and fh is used in a Lowpass filter. This convention is preserved in SeisBase.
 
 """
 const KW = KWDefs(

--- a/src/Types/SeisData.jl
+++ b/src/Types/SeisData.jl
@@ -16,8 +16,8 @@ processing univariate geophysical data.
 
 | **Field** | **Description**                                               |
 |:-------|:------                                                           |
-| :n     | Number of channels [^1]                                          |
-| :c     | TCP connections feeding data to this object [^1]                 |
+| :n     | Number of channels [1]                                           |
+| :c     | TCP connections feeding data to this object [1]                  |
 | :id    | Channel id. Uses NET.STA.LOC.CHA format when possible            |
 | :name  | Freeform channel name                                            |
 | :loc   | Location (position) vector; any subtype of InstrumentPosition    |
@@ -31,7 +31,7 @@ processing univariate geophysical data.
 | :t     | Matrix of time gaps in integer μs, formatted [Sample# Length]    |
 | :x     | Time-series data                                                 |
 
-[^1]: Not present in SeisChannel objects.
+1. Not present in SeisChannel objects.
 
 See also: `InstrumentPosition`, `PZResp`
 """

--- a/src/Wrappers/read_data.jl
+++ b/src/Wrappers/read_data.jl
@@ -46,7 +46,7 @@ matching pattern `filestr`. Much slower than manually specifying file type.
 
 This function is fully described in the official documentation at https://SeisBase.readthedocs.io/ (TODO: Change site) in section **Time-Series Files**.
 
-See also: [`SeisBase.KW`](@ref), [`get_data`](@ref), [`guess`](@ref), [`rseis`](@ref)
+See also: [`SeisBase.KW`](@ref seisbase_std_keyword), [`get_data`](@ref), [`guess`](@ref), [`rseis`](@ref)
 """
 function read_data!(S::GphysData, fmt::String, fpat::Union{String, Array{String,1}};
   cf      ::String  = "",                 # win32 channel info file
@@ -309,7 +309,7 @@ matching pattern `filestr`. Much slower than manually specifying file type.
 
 This function is fully described in the official documentation at https://SeisBase.readthedocs.io/ (TODO: Change site) in section **Time-Series Files**.
 
-See also: [`SeisBase.KW`](@ref), [`get_data`](@ref), [`guess`](@ref), [`rseis`](@ref)
+See also: [`SeisBase.KW`](@ref seisbase_std_keyword), [`get_data`](@ref), [`guess`](@ref), [`rseis`](@ref)
 """
 function read_data(fmt::String, filestr::Union{String, Array{String, 1}};
   full    ::Bool    = false,              # full SAC/SEGY hdr

--- a/src/Wrappers/read_meta.jl
+++ b/src/Wrappers/read_meta.jl
@@ -11,7 +11,7 @@ This function is fully described in the official documentation at https://SeisBa
 - `fmt::String`: Lowercase string describing the file format.
 - `fpat::Union{String, Vector{String}}`: Read files with names matching pattern ``filepat``. Supports wildcards.
 
-For information on keyword arguments, see [SeisBase.KW](@ref)
+For information on keyword arguments, see [SeisBase.KW](@ref seisbase_std_keyword)
 
 See also: `SeisBase.KW`, `get_data`, `read_data`
 """


### PR DESCRIPTION
Hi all,
 
As mentioned in the PR #2, I fixed the cross-reference from `rst` to `md` format. For future reference, this involves manually adding an ID to the referenced object:
```
## [Some Title](@id random_id)
```
and refer them:

```
[refer them](@ref random_id)
```

The footnote link in the table does not work well due to multiple doc string involved, so I hard code them below the table. 

Let me know if you found any problem in the documentations.

Yiyu 